### PR TITLE
Now with automatic builds pushing to docker hub

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,1 @@
+**node_modules**

--- a/.github/workflows/image.yml
+++ b/.github/workflows/image.yml
@@ -1,0 +1,24 @@
+name: Build multi-architecture images
+
+on:
+  push:
+    branches: master
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: checkout code
+        uses: actions/checkout@v2
+      - name: install buildx
+        id: buildx
+        uses: crazy-max/ghaction-docker-buildx@v1
+        with:
+          version: latest
+      - name: login to docker hub
+        run: echo "${{ secrets.DOCKER_PASSWORD }}" | docker login -u "${{ secrets.DOCKER_USERNAME }}" --password-stdin
+      - name: build the images
+        run: |
+          docker buildx build --push \
+            --tag richardsoper/nullboard:latest \
+            --platform linux/amd64,linux/arm/v7,linux/arm64 . 

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+**node_modules**

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,2 +1,3 @@
-FROM nginx
+ARG arch=
+FROM ${arch}nginx:1.18.0-alpine
 COPY ./app /usr/share/nginx/html

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ The name also happens to abbreviate to [NB](https://en.wikipedia.org/wiki/Nota_b
 
 ## Run with docker
 
-Run Nullboard in a docker container using `docker-compose build && docker-compose up -d`
+Run Nullboard in a docker container using `docker-compose up -d`. The image is now available on docker hub. 
 
 ## Dead simple
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,7 @@
 version: "3"
 services:
   nullboard:
-    build: .
+    image: richardsoper/nullboard:latest
     ports:
       - "80:80"
     container_name: "Nullboard"


### PR DESCRIPTION
Adding multi-architecture docker image generation and automatic push to docker hub. This should allow use without having to build the image yourself. 